### PR TITLE
Graceful fail remove missing

### DIFF
--- a/lib/ember-router-generator.js
+++ b/lib/ember-router-generator.js
@@ -139,7 +139,7 @@ EmberRouterGenerator.prototype._remove = function(nameParts, routes) {
   var newRoutes;
 
   if (children.length > 0) {
-    var routesFunction = findFunctionExpression(route.expression.arguments);
+    var routesFunction = route.expression && findFunctionExpression(route.expression.arguments);
 
     if (routesFunction) {
       newRoutes = this._remove(children, routesFunction.body.body);

--- a/tests/fixtures/missing-child-route.js
+++ b/tests/fixtures/missing-child-route.js
@@ -1,7 +1,9 @@
 Router.map(function() {
-  this.route('foo', function() {
-    this.route('bar', function() {
-      this.resource('baz', { path: 'baz' });
+  this.route("foo", function() {
+    this.route("bar", function() {
+      this.resource("baz", {
+        path: "baz"
+      });
     });
   });
 });

--- a/tests/fixtures/missing-child-route.js
+++ b/tests/fixtures/missing-child-route.js
@@ -1,0 +1,7 @@
+Router.map(function() {
+  this.route('foo', function() {
+    this.route('bar', function() {
+      this.resource('baz', { path: 'baz' });
+    });
+  });
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -184,6 +184,6 @@ describe('Removing routes and resources', function() {
 
     var newRoutes = routes.remove('baz/qux');
 
-    astEquality(recast.prettyPrint(newRoutes.ast).code, fs.readFileSync('./tests/fixtures/foos-resource.js'));
+    astEquality(recast.prettyPrint(newRoutes.ast).code, fs.readFileSync('./tests/fixtures/missing-child-route.js'));
   });
 });

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -177,4 +177,13 @@ describe('Removing routes and resources', function() {
 
     astEquality(recast.prettyPrint(newRoutes.ast).code, fs.readFileSync('./tests/fixtures/foos-resource.js'));
   });
+
+  it('fails gracefully when removing a route that does not exist', function() {
+    var source = fs.readFileSync('./tests/fixtures/missing-child-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('baz/qux');
+
+    astEquality(recast.prettyPrint(newRoutes.ast).code, fs.readFileSync('./tests/fixtures/foos-resource.js'));
+  });
 });


### PR DESCRIPTION
Under certain circumstances, asking ember-router-generator to remove a non-existant route would blow up (see screenshot).

This patch make `remove` fail silently, leaving the AST unmodified.

![ember-destroy-route-error](https://cloud.githubusercontent.com/assets/34030/6059467/c3c2d186-ad29-11e4-8a71-311cded967b4.png)
