### PR TITLE
Preexisting expression statements in the router causes a crash

### DIFF
--- a/lib/helpers/has-route.js
+++ b/lib/helpers/has-route.js
@@ -2,7 +2,7 @@ var recast = require('recast');
 
 function isRouteOrResource(node) {
   var callee = node.expression.callee;
-  return callee.type === 'MemberExpression' && (callee.property.name === 'route' || callee.property.name === 'resource');
+  return node.expression.type === 'CallExpression' && callee.type === 'MemberExpression' && (callee.property.name === 'route' || callee.property.name === 'resource');
 }
 
 module.exports = function hasRoute(name, routes) {

--- a/tests/fixtures/route-with-other-expressions-adding.js
+++ b/tests/fixtures/route-with-other-expressions-adding.js
@@ -1,0 +1,7 @@
+Router.map(function() {
+  42 === 42;
+  "string";
+  var i;
+  i = 42;
+  this.route('bar');
+});

--- a/tests/fixtures/route-with-other-expressions.js
+++ b/tests/fixtures/route-with-other-expressions.js
@@ -1,0 +1,6 @@
+Router.map(function() {
+  42 === 42;
+  "string";
+  var i;
+  i = 42;
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -128,6 +128,14 @@ describe('Adding routes and resources', function() {
 
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/route-with-if-adding.js'));
   });
+  it('adds routes even if other expression statements are present', function() {
+    var source = fs.readFileSync('./tests/fixtures/route-with-other-expressions.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.add('bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/route-with-other-expressions-adding.js'));
+  });
 });
 
 
@@ -201,5 +209,13 @@ describe('Removing routes and resources', function() {
     var newRoutes = routes.remove('foos');
 
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/route-with-if-removing.js'));
+  });
+  it('removes routes even if other expression statements are present', function() {
+    var source = fs.readFileSync('./tests/fixtures/route-with-other-expressions-adding.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/route-with-other-expressions.js'));
   });
 });


### PR DESCRIPTION
I added a check for the `CallExpression` type, since it seems like that's the only Expression type `isRouteOrResource` should care about.