### PR TITLE
Enable the resetNamespace option when generating routes

### DIFF
--- a/lib/helpers/route-node.js
+++ b/lib/helpers/route-node.js
@@ -16,7 +16,7 @@ module.exports = function routeNode(name, options) {
     )
   );
 
-  if (options.path) {
+  if (Object.keys(options).length) {
     node.expression.arguments.push(routeOptionsNode(options));
   }
 

--- a/lib/helpers/route-options-node.js
+++ b/lib/helpers/route-options-node.js
@@ -4,9 +4,10 @@ module.exports = function routeOptionNode(options) {
   options = options || {};
 
   var node = builders.objectExpression([]);
+  var properties = [];
 
   if (options.path) {
-    node.properties.push(
+    properties.push(
       builders.property(
         'init',
         builders.identifier('path'),
@@ -14,6 +15,18 @@ module.exports = function routeOptionNode(options) {
       )
     );
   }
+
+  if (options.hasOwnProperty('resetNamespace')) {
+    properties.push(
+      builders.property(
+        'init',
+        builders.identifier('resetNamespace'),
+        builders.literal(options.resetNamespace)
+      )
+    );
+  }
+
+  node.properties = node.properties.concat(properties);
 
   return node;
 };

--- a/tests/fixtures/edit-foo-route-with-reset-namespace-option.js
+++ b/tests/fixtures/edit-foo-route-with-reset-namespace-option.js
@@ -1,0 +1,3 @@
+Router.map(function() {
+  this.route('edit', { path: ':foo_id/edit', resetNamespace: false });
+});

--- a/tests/fixtures/foos-bar-route-with-reset-namespace-option.js
+++ b/tests/fixtures/foos-bar-route-with-reset-namespace-option.js
@@ -1,0 +1,5 @@
+Router.map(function() {
+  this.route('foos', function() {
+    this.route('bar', { resetNamespace: true });
+  });
+});

--- a/tests/fixtures/foos-with-reset-namespace-option.js
+++ b/tests/fixtures/foos-with-reset-namespace-option.js
@@ -1,0 +1,3 @@
+Router.map(function() {
+  this.route('foos', { resetNamespace: true });
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -235,4 +235,31 @@ describe('Removing routes', function() {
 
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-with-options-route.js'));
   });
+
+  it('can pass the resetNamespace option', function() {
+    var source = fs.readFileSync('./tests/fixtures/basic-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.add('foos', { resetNamespace: true });
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-with-reset-namespace-option.js'));
+  });
+
+  it('can pass the resetNamespace and path options', function() {
+    var source = fs.readFileSync('./tests/fixtures/basic-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.add('edit', { path: ':foo_id/edit', resetNamespace: false });
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/edit-foo-route-with-reset-namespace-option.js'));
+  });
+
+  it('can pass the resetNamespace option in nested routes', function() {
+    var source = fs.readFileSync('./tests/fixtures/foos-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.add('foos/bar', { resetNamespace: true });
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route-with-reset-namespace-option.js'));
+  });
 });

--- a/tests/helpers/esprima-ast-equality.js
+++ b/tests/helpers/esprima-ast-equality.js
@@ -12,6 +12,7 @@ EqualityError.prototype.constructor = EqualityError;
 
 var assert = require('assert');
 var esprima = require('esprima');
+var recast = require('recast');
 
 module.exports = function(actual, expected, message) {
   var parsedActual   = esprima.parse(actual);
@@ -21,8 +22,8 @@ module.exports = function(actual, expected, message) {
 
   if (!seemEqual) {
     throw new EqualityError(message || "AST equality failed",
-      parsedActual,
-      parsedExpected
+      recast.print(parsedActual).code,
+      recast.print(parsedExpected).code
     );
   }
 };


### PR DESCRIPTION
Since emberjs/ember.js#11517 `resource('some route')` is deprecated in favor of `route('some route', { resetNamespace: true })`. This PR enables the resetNamespace option in `routeGenerator#add`. For instance:

```js
routes.add('foos', { resetNamespace: true })
```

generates

```js
Router.map(function() {
  this.route('foos', { resetNamespace: true });
});
```

The idea is to use this option later in the ember-cli route generator via --reset-namespace