### PR TITLE
Use lastest available esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "assertion-error": "^1.0.0",
     "chai": "^1.9.1",
-    "esprima": "abuiles/esprima#harmony-esnext",
+    "esprima": "^2.6.0",
     "mocha": "~1.19.0",
     "mocha-jshint": "0.0.9"
   },


### PR DESCRIPTION
I don't know why this esprima branch was being used, so feel free to reject this PR if it doesn't make sense. But npm install from a github branch is pretty slow. I think this dependency is just used in the astEquality helper, and all tests pass for me, so I think it's worth to use the lastest available version.