### PR TITLE
Adding route beginning with /

### DIFF
--- a/lib/ember-router-generator.js
+++ b/lib/ember-router-generator.js
@@ -67,6 +67,10 @@ EmberRouterGenerator.prototype.add = function(routeName, options) {
 EmberRouterGenerator.prototype._add = function(nameParts, routes, options) {
   options = options || {};
   var parent   =  nameParts[0];
+  if(parent === ''){
+    nameParts.shift();
+    this._add(nameParts, routes, options);
+  }
   var name     = parent;
   var children = nameParts.slice(1);
   var path     = hasRoute(parent, routes);


### PR DESCRIPTION
Fix for adding route beginning with / like "/parent/route" which will add a route hirachy like this:
```
  this.route('', function() {
    this.route('parent', function() {
      this.route('route');
    });
  });
```