### PR TITLE
Fix esprima problems with object destructuring.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "url": "https://github.com/ember-cli/ember-router-generator.git"
   },
   "dependencies": {
-    "recast": "^0.9.16"
+    "recast": "^0.11.3"
   },
   "devDependencies": {
     "assertion-error": "^1.0.0",
     "chai": "^1.9.1",
-    "esprima": "^2.6.0",
+    "esprima": "^2.7.2",
     "mocha": "^2.3.3",
     "mocha-jshint": "0.0.9"
   },

--- a/tests/fixtures/basic-route-with-destructuring.js
+++ b/tests/fixtures/basic-route-with-destructuring.js
@@ -1,0 +1,4 @@
+const { get, run } = Ember;
+
+Router.map(function() {
+});

--- a/tests/fixtures/foos-route-with-destructuring.js
+++ b/tests/fixtures/foos-route-with-destructuring.js
@@ -1,0 +1,5 @@
+const { get, run } = Ember;
+
+Router.map(function() {
+  this.route('foos');
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -335,3 +335,14 @@ describe('Removing routes', function() {
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-with-options-route.js'));
   });
 });
+
+describe('esnext syntax compatibility', function() {
+  it('can add to a router file that uses destructuring', function() {
+    var source = fs.readFileSync('./tests/fixtures/basic-route-with-destructuring.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.add('foos');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-route-with-destructuring.js'));
+  });
+});


### PR DESCRIPTION
The version of recast and its downstream esprima dependency broke route generation if
you had anything like this in your router.js file.

```
const { get, run } = Ember;
```

Fixes #22.