### PR TITLE
Fix like-named route removal bug

### DIFF
--- a/lib/helpers/has-route.js
+++ b/lib/helpers/has-route.js
@@ -7,6 +7,10 @@ function isRoute(node, identifier) {
     (callee.property.name === 'route' || callee.property.name === identifier);
 }
 
+function isTopLevelExpression(path) {
+  return path.scope === null;
+}
+
 module.exports = function hasRoute(name, routes, identifier) {
   var nodePath = false;
 
@@ -15,6 +19,7 @@ module.exports = function hasRoute(name, routes, identifier) {
       var node = path.node;
 
       if (isRoute(node, identifier) &&
+          isTopLevelExpression(path) &&
           node.expression.arguments[0].value === name) {
         nodePath = path;
 

--- a/tests/fixtures/bar-foos-bar-route.js
+++ b/tests/fixtures/bar-foos-bar-route.js
@@ -1,0 +1,6 @@
+Router.map(function() {
+  this.route('bar');
+  this.route('foos', function() {
+    this.route('bar');
+  });
+});

--- a/tests/fixtures/foos-bar-post-bar-route.js
+++ b/tests/fixtures/foos-bar-post-bar-route.js
@@ -1,0 +1,6 @@
+Router.map(function() {
+  this.route('bar');
+  this.route('foos', function() {
+    this.route('bar');
+  });
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -334,6 +334,15 @@ describe('Removing routes', function() {
 
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-with-options-route.js'));
   });
+
+  it('removes routes that have an identically named nested route elsewhere', function() {
+    var source = fs.readFileSync('./tests/fixtures/bar-foos-bar-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route.js'));
+  });
 });
 
 describe('esnext syntax compatibility', function() {

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -236,6 +236,15 @@ describe('Removing routes', function() {
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-route.js'));
   });
 
+  it('does not remove nested routes inappropriately', function() {
+      var source = fs.readFileSync('./tests/fixtures/foos-bar-route.js');
+      var routes = new EmberRouterGenerator(source);
+
+      var newRoutes = routes.remove('bar');
+
+      astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route.js'));
+  });
+
   it('removes deeply nested routes', function() {
     var source = fs.readFileSync('./tests/fixtures/foos-bar-baz-route.js');
     var routes = new EmberRouterGenerator(source);

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -344,8 +344,17 @@ describe('Removing routes', function() {
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-with-options-route.js'));
   });
 
-  it('removes routes that have an identically named nested route elsewhere', function() {
+  it('removes routes that have an identically named nested route after them', function() {
     var source = fs.readFileSync('./tests/fixtures/bar-foos-bar-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route.js'));
+  });
+
+  it('removes routes that have an identically named nested route before them', function() {
+    var source = fs.readFileSync('./tests/fixtures/foos-bar-post-bar-route.js');
     var routes = new EmberRouterGenerator(source);
 
     var newRoutes = routes.remove('bar');


### PR DESCRIPTION
This is the start of a fix for the bug reported [here](https://github.com/ember-cli/ember-cli/issues/5303).

The bug is that if you have a top-level route and an identically-named nested route, destroying the top-level route removes the nested route instead.

The bug gets nastier with index routes. Attempting to remove a nested index route can remove everything under your top-level index route.

It turns out the recipe with non-index routes is a little more specific than reported in the issue. The bug only occurs if the top-level route being destroyed occurs _before_ the nested routes in the router file.