### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ node_js:
   - '0.12'
   - '4'
   - '6'
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: mjbVCbbvGouyNmo3mi0anoUH4ktpfnSLwUYgJjnLUHQQVOHEmw/N41tEXCOv0IjZVjjMBknPs3T/aflcT6r8/zvpQjtT5F4n8/GL3Wy7DdG2P4NIm9S70EbyutETNhxx6axJA7TpHMUkQp24IyxRdt6hTqf9BGAws/tjQ3hZjR8=
+  on:
+    tags: true
+    repo: ember-cli/ember-router-generator


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`git owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue