### PR TITLE
Remove all instances of the specified route

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+insert_final_newline = false
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/lib/ember-router-generator.js
+++ b/lib/ember-router-generator.js
@@ -1,11 +1,11 @@
 module.exports = EmberRouterGenerator;
 
-var recast    = require('recast');
+var recast = require('recast');
 
 var findFunctionExpression = require('./helpers/find-function-expression');
-var hasRoute               = require('./helpers/has-route');
-var newFunctionExpression  = require('./helpers/new-function-expression');
-var routeNode              = require('./helpers/route-node');
+var findRoutes = require('./helpers/find-routes');
+var newFunctionExpression = require('./helpers/new-function-expression');
+var routeNode = require('./helpers/route-node');
 
 function EmberRouterGenerator(source, ast) {
   this.source = source;
@@ -17,9 +17,7 @@ function EmberRouterGenerator(source, ast) {
 }
 
 EmberRouterGenerator.prototype.clone = function() {
-  var route = new EmberRouterGenerator(this.code());
-
-  return route;
+  return new EmberRouterGenerator(this.code());
 };
 
 EmberRouterGenerator.prototype._ast  = function() {
@@ -66,11 +64,11 @@ EmberRouterGenerator.prototype.add = function(routeName, options) {
 
 EmberRouterGenerator.prototype._add = function(nameParts, routes, options) {
   options = options || {};
-  var parent   =  nameParts[0];
-  var name     = parent;
+  var parent = nameParts[0];
+  var name = parent;
   var children = nameParts.slice(1);
-  var path     = hasRoute(parent, routes, options.identifier);
-  var route    = path ? path.node : path;
+  var paths = findRoutes(parent, routes, options.identifier);
+  var route = paths.length ? paths[paths.length - 1].node : false;
 
   if (!route) {
     route = routeNode(name, options);
@@ -100,7 +98,7 @@ EmberRouterGenerator.prototype.remove = function(routeName, options) {
   options = options || {};
 
   var route = this.clone();
-  var routes  = route.mapNode.arguments[0].body.body;
+  var routes = route.mapNode.arguments[0].body.body;
 
   var newRoutes = route._remove.call(
     route,
@@ -117,11 +115,20 @@ EmberRouterGenerator.prototype.remove = function(routeName, options) {
 };
 
 EmberRouterGenerator.prototype._remove = function(nameParts, routes, options) {
-  var parent   =  nameParts[0];
-  var name     = parent;
+  var parent = nameParts[0];
   var children = nameParts.slice(1);
-  var path     = hasRoute(parent, routes, options.identifier);
-  var route    = path ? path.node : path;
+  var paths = findRoutes(parent, routes, options.identifier);
+  var context = this;
+
+  return paths.reduce(function(routes, path) {
+    var newRoutes = context._removePath(routes, parent, children, path, options);
+
+    return newRoutes || routes;
+  }, false);
+};
+
+EmberRouterGenerator.prototype._removePath = function(routes, parent, children, path, options) {
+  var route = path ? path.node : path;
   var newRoutes;
 
   if (children.length > 0) {

--- a/lib/helpers/find-routes.js
+++ b/lib/helpers/find-routes.js
@@ -11,8 +11,8 @@ function isTopLevelExpression(path) {
   return path.scope === null;
 }
 
-module.exports = function hasRoute(name, routes, identifier) {
-  var nodePath = false;
+module.exports = function findRoutes(name, routes, identifier) {
+  var nodePaths = [];
 
   recast.visit(routes, {
     visitExpressionStatement: function(path) {
@@ -21,7 +21,7 @@ module.exports = function hasRoute(name, routes, identifier) {
       if (isRoute(node, identifier) &&
           isTopLevelExpression(path) &&
           node.expression.arguments[0].value === name) {
-        nodePath = path;
+        nodePaths.push(path);
 
         return false;
       } else {
@@ -30,5 +30,5 @@ module.exports = function hasRoute(name, routes, identifier) {
     }
   });
 
-  return nodePath;
+  return nodePaths;
 };

--- a/tests/fixtures/bar-foos-double-bar-route.js
+++ b/tests/fixtures/bar-foos-double-bar-route.js
@@ -1,0 +1,7 @@
+Router.map(function() {
+  this.route('bar');
+  this.route('foos', function() {
+    this.route('bar');
+    this.route('bar');
+  });
+});

--- a/tests/fixtures/bar-foos-index-route.js
+++ b/tests/fixtures/bar-foos-index-route.js
@@ -1,0 +1,4 @@
+Router.map(function() {
+  this.route('bar');
+  this.route('foos', function() {});
+});

--- a/tests/fixtures/double-foos-route.js
+++ b/tests/fixtures/double-foos-route.js
@@ -1,0 +1,4 @@
+Router.map(function() {
+  this.route('foos');
+  this.route('foos');
+});

--- a/tests/fixtures/foos-double-bar-route.js
+++ b/tests/fixtures/foos-double-bar-route.js
@@ -1,0 +1,6 @@
+Router.map(function() {
+  this.route('foos', function() {
+    this.route('bar');
+    this.route('bar');
+  });
+});

--- a/tests/fixtures/multi-bar-foos-bar-route.js
+++ b/tests/fixtures/multi-bar-foos-bar-route.js
@@ -1,0 +1,7 @@
+Router.map(function() {
+  this.route('bar');
+  this.route('bar');
+  this.route('foos', function() {
+    this.route('bar');
+  });
+});

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -361,6 +361,42 @@ describe('Removing routes', function() {
 
     astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route.js'));
   });
+
+  it('removes duplicate copies of the specified top-level route', function() {
+    var source = fs.readFileSync('./tests/fixtures/double-foos-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('foos');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/basic-route.js'));
+  });
+
+  it('removes duplicate copies of the specified nested route', function() {
+    var source = fs.readFileSync('./tests/fixtures/foos-double-bar-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('foos/bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-index-route.js'));
+  });
+
+  it('removes duplicate copies of the specified top-level route when there is a preceding identically named nested route', function() {
+    var source = fs.readFileSync('./tests/fixtures/multi-bar-foos-bar-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/foos-bar-route.js'));
+  });
+
+  it('removes duplicate copies of the specified nested route when there are identically named top-level routes', function() {
+    var source = fs.readFileSync('./tests/fixtures/bar-foos-double-bar-route.js');
+    var routes = new EmberRouterGenerator(source);
+
+    var newRoutes = routes.remove('foos/bar');
+
+    astEquality(newRoutes.code(), fs.readFileSync('./tests/fixtures/bar-foos-index-route.js'));
+  });
 });
 
 describe('esnext syntax compatibility', function() {


### PR DESCRIPTION
@nathanhammond identified in #36 that there may be a problem with duplicate instances of the same route. The fix is a bit different, so I thought it better as a separate PR than that one because it will have broader impact due to necessary changes in the return type of `hasRoute`.