### PR TITLE
Drop support for Node 4 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
   - '6'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - '6'
+  - '8'
 
 deploy:
   provider: npm

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "bugs": {
     "url": "https://github.com/ember-cli/ember-router-generator/issues"
   },
-  "homepage": "https://github.com/ember-cli/ember-router-generator"
+  "homepage": "https://github.com/ember-cli/ember-router-generator",
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  }
 }


### PR DESCRIPTION
This should unblock some of the failing dependency update PRs